### PR TITLE
Fix client timing 2020 w11

### DIFF
--- a/client/cronjob
+++ b/client/cronjob
@@ -1,1 +1,1 @@
-*/5 * * * *   root  /usr/sbin/nivlheim_client -minperiod 2700 -sleeprandom 1800 > /dev/null
+*/5 * * * *   root  /usr/sbin/nivlheim_client -minperiod 2580 -sleeprandom 1800 > /dev/null

--- a/client/cronjob
+++ b/client/cronjob
@@ -1,1 +1,1 @@
-*/5 * * * *   root  /usr/sbin/nivlheim_client -minperiod 3300 -sleeprandom 300 > /dev/null
+*/5 * * * *   root  /usr/sbin/nivlheim_client -minperiod 3240 -sleeprandom 600 > /dev/null

--- a/client/cronjob
+++ b/client/cronjob
@@ -1,1 +1,1 @@
-*/5 * * * *   root  /usr/sbin/nivlheim_client -minperiod 3240 -sleeprandom 600 > /dev/null
+*/5 * * * *   root  /usr/sbin/nivlheim_client -minperiod 2700 -sleeprandom 1800 > /dev/null

--- a/client/nivlheim_client
+++ b/client/nivlheim_client
@@ -260,6 +260,13 @@ if ($have_cert) {
 	}
 }
 
+# Verify that it is possible to write 16kB to the location where certificates are stored
+my $fn = dirname($opt{cert_file})."/temp";
+open(my $F2, ">$fn") || die "Unable to open $fn for writing";
+unlink($fn);
+print $F2 "a" x 16384 || die "Unable to write to $fn";
+close($F2);
+
 # Is there a client certificate present? Test if it works
 my $cert_works = 0;
 if ($have_cert) {

--- a/client/nivlheim_client
+++ b/client/nivlheim_client
@@ -126,8 +126,8 @@ if ($opt{version}) {
 }
 
 # minimum period between successful runs
+my @stat = stat "/var/run/nivlheim_client_last_run";
 if ($opt{minperiod}) {
-	my @stat = stat "/var/run/nivlheim_client_last_run";
 	if ($#stat>=0) {
 		my $seconds_since_last_time = time()-$stat[9];
 		if ($seconds_since_last_time < $opt{minperiod}) {
@@ -147,8 +147,8 @@ unless ( flock SELF, LOCK_EX | LOCK_NB ) {
 	exit;
 }
 
-# sleep if cmdline parameter says so
-if ($opt{sleeprandom}) {
+# sleep if cmdline parameter says so, and there has been at least one successful run earlier
+if ($opt{sleeprandom} && $#stat>=0) {
 	print "sleeping...\n" if ($opt{debug});
 	sleep int(rand($opt{sleeprandom}));
 }

--- a/client/nivlheim_client
+++ b/client/nivlheim_client
@@ -27,6 +27,7 @@ use Archive::Tar;
 use HTTP::Request::Common;
 use Sys::Hostname;
 use Sys::Syslog qw(:standard :macros);
+use Fcntl ':flock';
 use File::Path qw(remove_tree mkpath);
 use File::Basename;
 use Getopt::Long qw(:config no_ignore_case);
@@ -124,16 +125,6 @@ if ($opt{version}) {
 	exit 0;
 }
 
-# sleep if cmdline parameter says so
-if ($opt{sleeprandom}) {
-	# Take the sum of the characters in the hostname,
-	# divide by the parameter value and take the remainder.
-	# Sleep that many seconds.
-	# (i.e. a "random" delay but the same every time)
-	print "sleeping...\n" if ($opt{debug});
-	sleep unpack("%32W*",hostname) % $opt{sleeprandom};
-}
-
 # minimum period between successful runs
 if ($opt{minperiod}) {
 	my @stat = stat "/var/run/nivlheim_client_last_run";
@@ -145,6 +136,21 @@ if ($opt{minperiod}) {
 			exit 64
 		}
 	}
+}
+
+# If another instance of this script is already running, exit.
+# Implemented this way because we don't want the package to depend on EPEL,
+# and unfortunately all the Perl modules for checking PID are there.
+open SELF, "< $0" or exit;
+unless ( flock SELF, LOCK_EX | LOCK_NB ) {
+	# Another instance is running
+	exit;
+}
+
+# sleep if cmdline parameter says so
+if ($opt{sleeprandom}) {
+	print "sleeping...\n" if ($opt{debug});
+	sleep int(rand($opt{sleeprandom}));
 }
 
 # Log to stdout or syslog depending on whether we have a TTY

--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.2"
+Set-Variable version -option Constant -value "2.7.3"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx

--- a/client/windows/test_windows_client.sh
+++ b/client/windows/test_windows_client.sh
@@ -38,7 +38,7 @@ echo "IP address: \"$WINIP\""
 echo "Creating a Fedora VM..."
 FED="Trilby"
 openstack server delete --wait $FED 2>/dev/null || true # just to be sure
-openstack server create --flavor m1.small --image "GOLD Fedora 30" --nic net-id=dualStack --key-name $KEYPAIRNAME --wait $FED
+openstack server create --flavor m1.small --image "GOLD Fedora 31" --nic net-id=dualStack --key-name $KEYPAIRNAME --wait $FED
 FEDIP=$(openstack server list | grep $FED | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
 echo "IP address: \"$FEDIP\""
 

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.2
+Version:  2.7.3
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/rpm/run_tests_on_vms.sh
+++ b/rpm/run_tests_on_vms.sh
@@ -38,7 +38,7 @@ rm $TMPFILE
 # Clean up the list, only keep the images we want to test on
 IMAGES=()
 for IMAGE in "${LIST[@]}"; do
-	if [[ $IMAGE != *"Fedora 30"* ]] && [[ $IMAGE != *"CentOS 7"* ]]; then
+	if [[ $IMAGE != *"Fedora 31"* ]] && [[ $IMAGE != *"CentOS 7"* ]]; then
 		continue
 	fi
 	IMAGE=$(echo $IMAGE | xargs) # trim leading/trailing whitespace

--- a/server/service/parseFiles.go
+++ b/server/service/parseFiles.go
@@ -230,11 +230,11 @@ func parseFile(database *sql.DB, fileID int64) {
 	}
 
 	if strings.EqualFold(filename.String, "(Get-WmiObject Win32_OperatingSystem).Caption") {
-		reWinX := regexp.MustCompile(`Microsoft Windows (\d+)`)
+		reWinX := regexp.MustCompile(`Microsoft Windows (\d+) (.*)`)
 		reWinServer := regexp.MustCompile(`Microsoft®? Windows Server®? (\d+)( R2)?`)
 		if m := reWinX.FindStringSubmatch(content.String); m != nil {
-			_, err = tx.Exec("UPDATE hostinfo SET os=$1, os_edition=null, os_family='Windows' "+
-				"WHERE certfp=$2", "Windows "+m[1], certfp.String)
+			_, err = tx.Exec("UPDATE hostinfo SET os=$1, os_edition=$2, os_family='Windows' "+
+				"WHERE certfp=$3", "Windows "+m[1], m[2], certfp.String)
 		} else if m := reWinServer.FindStringSubmatch(content.String); m != nil {
 			_, err = tx.Exec("UPDATE hostinfo SET os=$1, os_edition='Server', os_family='Windows' "+
 				"WHERE certfp=$2", fmt.Sprintf("Windows %s%s", m[1], m[2]),


### PR DESCRIPTION
- Linux client changes:
  - The cron job is modified to greater vary the timing
  - Add a locking method to exit if another instance is already running
  - Don't sleep/delay on first time run
  - Before requesting a new certificate, verify that there's enough space to store the certificate files

- Server changes:
  - For Windows 10 machines, parse the edition (Home, Pro etc.) from collected data

- Build changes
  - Build/test on Fedora 31 instead of 30