### PR TITLE
Add a config option to hide unknown hosts

### DIFF
--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.3"
+Set-Variable version -option Constant -value "2.7.4"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx

--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.4"
+Set-Variable version -option Constant -value "2.7.5"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx

--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.5"
+Set-Variable version -option Constant -value "2.7.6"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.3
+Version:  2.7.4
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -24,6 +24,14 @@ Source9:  https://use.fontawesome.com/releases/v5.2.0/fontawesome-free-5.2.0-web
 Source10: https://raw.githubusercontent.com/wycats/handlebars.js/master/LICENSE
 Source11: https://github.com/go-ldap/ldap/archive/v3.0.3.zip#/ldap-v3.tar.gz
 Source12: https://github.com/go-asn1-ber/asn1-ber/archive/v1.3.zip#/asn1-ber-v1.tar.gz
+Source13: https://github.com/jcmturner/gokrb5/archive/master.tar.gz#/gokrb5-master.tar.gz
+Source14: https://github.com/jcmturner/aescts/archive/master.tar.gz#/aescts-master.tar.gz
+Source15: https://github.com/jcmturner/dnsutils/archive/master.tar.gz#/dnsutils-master.tar.gz
+Source16: https://github.com/jcmturner/gofork/archive/master.tar.gz#/gofork-master.tar.gz
+Source17: https://github.com/jcmturner/goidentity/archive/master.tar.gz#/goidentity-master.tar.gz
+Source18: https://github.com/jcmturner/rpc/archive/master.tar.gz#/rpc-master.tar.gz
+Source19: https://github.com/golang/crypto/archive/master.tar.gz#/crypto-master.tar.gz
+Source20: https://github.com/hashicorp/go-uuid/archive/master.tar.gz#/go-uuid-master.tar.gz
 
 BuildRequires: npm(handlebars)
 BuildRequires: perl(Archive::Tar)
@@ -131,6 +139,14 @@ This package contains the server components of Nivlheim.
 %setup -q -T -b 8 -n tarantino-2.1.0
 %setup -q -T -b 11 -n ldap-3.0.3
 %setup -q -T -b 12 -n asn1-ber-1.3
+%setup -q -T -b 13 -n gokrb5-master
+%setup -q -T -b 14 -n aescts-master
+%setup -q -T -b 15 -n dnsutils-master
+%setup -q -T -b 16 -n gofork-master
+%setup -q -T -b 17 -n goidentity-master
+%setup -q -T -b 18 -n rpc-master
+%setup -q -T -b 19 -n crypto-master
+%setup -q -T -b 20 -n go-uuid-master
 %autosetup -D -n %{name}-%{getenv:GIT_BRANCH}
 A=`pwd`
 cd `dirname %{SOURCE0}`
@@ -170,6 +186,16 @@ mv ../pq-master $GOPATH/src/github.com/lib/pq
 mkdir -p $GOPATH/src/golang.org/x
 mv ../net-master $GOPATH/src/golang.org/x/net
 mv ../oauth2-master $GOPATH/src/golang.org/x/oauth2
+mv ../crypto-master $GOPATH/src/golang.org/x/crypto
+mkdir -p $GOPATH/src/github.com/jcmturner
+mv ../gokrb5-master $GOPATH/src/github.com/jcmturner/gokrb5
+mv ../aescts-master $GOPATH/src/github.com/jcmturner/aescts
+mv ../dnsutils-master $GOPATH/src/github.com/jcmturner/dnsutils
+mv ../gofork-master $GOPATH/src/github.com/jcmturner/gofork
+mv ../goidentity-master $GOPATH/src/github.com/jcmturner/goidentity
+mv ../rpc-master $GOPATH/src/github.com/jcmturner/rpc
+mkdir -p $GOPATH/src/github.com/hashicorp
+mv ../go-uuid-master $GOPATH/src/github.com/hashicorp/go-uuid
 mkdir -p $GOPATH/src/gopkg.in/
 mv ../ldap-3.0.3 $GOPATH/src/gopkg.in/ldap.v3
 mv ../asn1-ber-1.3 $GOPATH/src/gopkg.in/asn1-ber.v1

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.5
+Version:  2.7.6
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.4
+Version:  2.7.5
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/server/server.conf
+++ b/server/server.conf
@@ -8,6 +8,7 @@ Oauth2LogoutEndpoint=
 AuthRequired=no
 ArchiveDayLimit=
 DeleteDayLimit=
+HideUnknownHosts=
 LDAPserver=
 LDAPusertree=
 LDAPmemberAttr=

--- a/server/server.conf-example.txt
+++ b/server/server.conf-example.txt
@@ -8,6 +8,7 @@ Oauth2LogoutEndpoint=https://auth.dataporten.no/logout
 AuthRequired=yes
 ArchiveDayLimit=30
 DeleteDayLimit=180
+HideUnknownHosts=yes
 LDAPserver=ldap.example.com
 LDAPusertree=cn=users,cn=system,dc=example,dc=com
 LDAPmemberAttr=memberOf

--- a/server/service/api_file.go
+++ b/server/service/api_file.go
@@ -86,6 +86,10 @@ func (vars *apiMethodFile) ServeHTTP(w http.ResponseWriter, req *http.Request, a
 			if !access.HasAccessToAllGroups() {
 				statement += " AND h.ownergroup IN (" + access.GetGroupListForSQLWHERE() + ")"
 			}
+			// Possibly filter out hosts with undetermined hostnames
+			if config.HideUnknownHosts {
+				statement += " AND h.hostname IS NOT NULL"
+			}
 			// Any requirement for lastseen?
 			matches := regexp.MustCompile(`lastseen([<>=])(\d+)([smhd])`).
 				FindStringSubmatch(req.URL.RawQuery)

--- a/server/service/api_hostlist.go
+++ b/server/service/api_hostlist.go
@@ -99,6 +99,12 @@ func (vars *apiMethodHostList) ServeGET(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	// Possibly filter out hosts with undetermined hostnames
+	if config.HideUnknownHosts {
+		if where != "" { where += " AND " }
+		where += "h.hostname IS NOT NULL"
+	}
+
 	// Build the "SELECT ... " part of the statement, including custom fields
 	// Start with the standard fields:
 	temp := make([]string, 0, len(apiHostListStandardFields))

--- a/server/service/api_search.go
+++ b/server/service/api_search.go
@@ -126,9 +126,26 @@ func (vars *apiMethodSearch) ServeHTTP(w http.ResponseWriter, req *http.Request,
 		}
 
 		// Prepare SQL statement
+		statement := "SELECT " + strings.Join(temp, ",") + " FROM files f, hostinfo h " +
+					"WHERE f.certfp=h.certfp AND f.fileID=$1"
+		// Possibly filter out hosts with undetermined hostnames
+		if config.HideUnknownHosts {
+			statement += " AND h.hostname IS NOT NULL"
+		}
+		prepStatmt, err = vars.db.Prepare(statement)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer prepStatmt.Close()
+	}
+
+	// Possibly filter out hosts with undetermined hostnames,
+	// if it hasn't already been done by the code above
+	if config.HideUnknownHosts && prepStatmt == nil {
 		prepStatmt, err = vars.db.Prepare(
-			"SELECT " + strings.Join(temp, ",") + " FROM files f, hostinfo h " +
-				"WHERE f.certfp=h.certfp AND f.fileID=$1")
+			"SELECT fileid FROM files f, hostinfo h WHERE f.certfp=h.certfp "+
+			"AND f.fileID=$1 AND h.hostname IS NOT NULL")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/server/service/api_search_multi.go
+++ b/server/service/api_search_multi.go
@@ -172,9 +172,25 @@ func (vars *apiMethodMultiStageSearch) ServeHTTP(w http.ResponseWriter, req *htt
 		}
 
 		// Prepare SQL statement
+		statement := "SELECT " + strings.Join(temp, ",") + " FROM hostinfo " +
+					"WHERE certfp=$1"
+		// Possibly filter out hosts with undetermined hostnames
+		if config.HideUnknownHosts {
+			statement += " AND hostname IS NOT NULL"
+		}
+		prepStatmt, err = vars.db.Prepare(statement)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer prepStatmt.Close()
+	}
+
+	// Possibly filter out hosts with undetermined hostnames,
+	// if it hasn't already been done by the code above
+	if config.HideUnknownHosts && prepStatmt == nil {
 		prepStatmt, err = vars.db.Prepare(
-			"SELECT " + strings.Join(temp, ",") + " FROM hostinfo " +
-				"WHERE certfp=$1")
+			"SELECT hostname FROM hostinfo WHERE certfp=$1 AND hostname IS NOT NULL")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/server/service/api_searchpage.go
+++ b/server/service/api_searchpage.go
@@ -141,6 +141,9 @@ func (vars *apiMethodSearchPage) ServeHTTP(w http.ResponseWriter, req *http.Requ
 		"COALESCE(hostname,host(hostinfo.ipaddr)),certfp,content " +
 		"FROM files LEFT JOIN hostinfo USING (certfp) " +
 		"WHERE fileid=$1"
+	if config.HideUnknownHosts {
+		statement += " AND hostinfo.hostname IS NOT NULL"
+	}
 
 	offset := (result.Page - 1) * pageSize
 	for i := offset; i < offset+pageSize && i < len(hitIDs); i++ {
@@ -151,7 +154,7 @@ func (vars *apiMethodSearchPage) ServeHTTP(w http.ResponseWriter, req *http.Requ
 		err = vars.db.QueryRow(statement, fileID).
 			Scan(&filename, &isCommand, &hostname, &certfp, &content)
 		if err == sql.ErrNoRows {
-			log.Printf("Didn't find the file %d", fileID)
+			//log.Printf("Didn't find the file %d", fileID)
 			continue
 		}
 		if err != nil {

--- a/server/service/config.go
+++ b/server/service/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	AuthRequired                bool
 	ArchiveDayLimit             int
 	DeleteDayLimit              int
+	HideUnknownHosts            bool
 	LDAPServer                  string
 	LDAPUserTree                string
 	LDAPMemberAttr              string


### PR DESCRIPTION
- Unknown hosts are hosts where Nivlheim is unable to determine their hostname. That can happen because of incongruency between DNS, the hostname reported by the OS, other hosts that claim the same name, etc. Currently, they are listed by their IP address in Nivlheim.
This new config option allows you to prevent these hosts from showing up in Nivlheim until their hostname has been determined (if that happens).

- Also, the Go library [github.com/lib/pq](https://github.com/lib/pq) just got Kerberos support, and became dependent on [another library](https://github.com/jcmturner/gokrb5) for that, which in turn has other dependencies. This PR adds all the necessary dependencies to the rpm spec file.