### PR TITLE
Fix a bug in hostlist API about ipaddr wildcard

### DIFF
--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.3"
+Set-Variable version -option Constant -value "2.7.4"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.3
+Version:  2.7.4
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/server/service/api_hostlist.go
+++ b/server/service/api_hostlist.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -21,11 +22,12 @@ type apiMethodHostList struct {
 type apiHostListStandardField struct {
 	publicName string
 	columnName string
+	expression string
 }
 
 var apiHostListStandardFields = []apiHostListStandardField{
-	{publicName: "ipAddress", columnName: "host(ipaddr)"},
-	{publicName: "hostname", columnName: "hostname"},
+	{publicName: "ipAddress", columnName: "ipaddr", expression: "host(ipaddr)"},
+	{publicName: "hostname", columnName: "hostname", expression: "COALESCE(hostname,host(ipaddr))"},
 	{publicName: "lastseen", columnName: "lastseen"},
 	{publicName: "os", columnName: "os"},
 	{publicName: "osEdition", columnName: "os_edition"},
@@ -103,8 +105,8 @@ func (vars *apiMethodHostList) ServeGET(w http.ResponseWriter, req *http.Request
 	// Start with the standard fields:
 	temp := make([]string, 0, len(apiHostListStandardFields))
 	for _, f := range apiHostListStandardFields {
-		if f.columnName == "hostname" {
-			temp = append(temp, "COALESCE(hostname,host(ipaddr)) as hostname")
+		if f.expression != "" {
+			temp = append(temp, f.expression + " AS " + f.columnName)
 		} else {
 			temp = append(temp, f.columnName)
 		}
@@ -194,14 +196,13 @@ func (vars *apiMethodHostList) ServeGET(w http.ResponseWriter, req *http.Request
 	}
 	*/
 
-	/*if vars.devmode {
-		log.Println(statement)
-		log.Print(qparams)
-	}*/
-
 	rows, err := vars.db.Query(statement, qparams...)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		if vars.devmode {
+			log.Println(statement)
+			log.Print(qparams)
+		}
 		return
 	}
 	defer rows.Close()

--- a/server/service/api_hostlist_test.go
+++ b/server/service/api_hostlist_test.go
@@ -234,6 +234,11 @@ func TestApiMethodHostList(t *testing.T) {
 			expectStatus:   http.StatusOK,
 			expectContent:  "Updated 0 hosts, created 0 new hosts, 0 errors.",
 		},
+		// Regression test for a bug (See GitHub issue #151)
+		{
+			methodAndPath:  "GET /api/v2/hostlist?fields=hostname,os,duck&ipAddress=129.240.98.*",
+			expectStatus:   http.StatusOK,
+		},
 	}
 
 	db := getDBconnForTesting(t)

--- a/server/service/api_search.go
+++ b/server/service/api_search.go
@@ -96,10 +96,9 @@ func (vars *apiMethodSearch) ServeHTTP(w http.ResponseWriter, req *http.Request,
 		temp := make([]string, 0, len(fields))
 		for _, f := range apiHostListStandardFields {
 			if fields[f.publicName] {
-				if f.publicName == "hostname" {
-					temp = append(temp, "COALESCE(hostname,host(h.ipaddr))")
-				} else if f.publicName == "ipAddress" {
-					temp = append(temp, "host(h.ipaddr)")
+				if f.expression != "" {
+					// both files and hostlist tables have a column called ipaddr
+					temp = append(temp, strings.Replace(f.expression, "ipaddr", "h.ipaddr", -1))
 				} else {
 					temp = append(temp, "h."+f.columnName)
 				}

--- a/server/service/api_search_multi.go
+++ b/server/service/api_search_multi.go
@@ -150,10 +150,8 @@ func (vars *apiMethodMultiStageSearch) ServeHTTP(w http.ResponseWriter, req *htt
 		temp := make([]string, 0, len(fields))
 		for _, f := range apiHostListStandardFields {
 			if fields[f.publicName] {
-				if f.publicName == "hostname" {
-					temp = append(temp, "COALESCE(hostname,host(ipaddr))")
-				} else if f.publicName == "ipAddress" {
-					temp = append(temp, "host(ipaddr)")
+				if f.expression != "" {
+					temp = append(temp, f.expression)
 				} else {
 					temp = append(temp, f.columnName)
 				}


### PR DESCRIPTION
The following API call:
`hostlist?fields=hostname,os,siteadmin&ipAddress=129.240.98.*`
returns this error message:
`pq: column "ipaddr" does not exist`

Fixes #151.