### PR TITLE
LDAP lookup additional username

### DIFF
--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.6"
+Set-Variable version -option Constant -value "2.7.7"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.6
+Version:  2.7.7
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/server/service/oauth2login.go
+++ b/server/service/oauth2login.go
@@ -169,7 +169,13 @@ func handleOauth2Redirect(w http.ResponseWriter, req *http.Request) {
 		// Also look up the "drift" user and add the groups from there.
 		// This solution is probably only used by UiO,
 		// but is likely to be harmless in other environments.
-		user2, err := LDAPLookupUser(session.userinfo.Username + "-drift")
+		var otherUsername string
+		if strings.HasSuffix(session.userinfo.Username, "-drift") {
+			otherUsername = session.userinfo.Username[0:len(session.userinfo.Username)-6]
+		} else {
+			otherUsername = session.userinfo.Username + "-drift"
+		}
+		user2, err := LDAPLookupUser(otherUsername)
 		if err != nil {
 			log.Printf("Unable to LDAP: %v", err)
 			http.Error(w, "Unable to perform LDAP lookup", http.StatusInternalServerError)


### PR DESCRIPTION
For å kunne logge inn med både "driftsbrukere" og vanlige brukere, må systemet slå opp gruppetilhørighetene for "den andre" brukeren - uavhengig av hvilken bruker som logget inn.