### PR TITLE
Fix a bug in the Windows client (didn't send hostname to reqcert)

### DIFF
--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -37,6 +37,7 @@ Set-Variable version -option Constant -value "2.7.8"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx
+Add-Type -Assembly System.Web   # we need System.Web.HttpUtility
 
 # syntax for putting functions in a separate file:
 # $functions = "$($MyInvocation.MyCommand.path | split-path)\functions.ps1"
@@ -135,7 +136,7 @@ function http($uri, $method = "get", $timeoutSeconds = 60, $clientCert = $null, 
 	if ($params -and ($method -eq "post")) {
 		$WebRequest.ContentType = "application/x-www-form-urlencoded"
 		# convert dictionary to query string
-		Add-Type -Assembly System.Web
+		# Add-Type -Assembly System.Web  # was done at the start of the script, no need to do it here
 		$str = ""
 		$params.Keys | ForEach-Object {
 			$str += [System.Web.HttpUtility]::UrlEncode($_)

--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -19,7 +19,7 @@ nivlheim_client.ps1
 .Inputs
 None
 .Notes
-Last Updated: 2019-12-09
+Last Updated: 2020-12-08
 Authors     : Øyvind Hagberg, Mustafa Ocak
 #>
 
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.7"
+Set-Variable version -option Constant -value "2.7.8"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx
@@ -565,11 +565,12 @@ if ($haveCert -and -not $certWorks) {
 	Write-Host "My certificate doesn't work. Trying to renew it..."
 	$r = $null
 	try {
-		$url = $serverbaseurl + "secure/renewcert?nopass=1"
+		$url = $serverbaseurl + "secure/renewcert"
 		$r = http $url "get" 60 $cert
 	} catch {
 		Write-Host "Renewing didn't work, trying to request a new one"
-		$url = $serverbaseurl + "reqcert?nopass=1"
+		$hostname = [System.Web.HttpUtility]::UrlEncode([System.Net.Dns]::GetHostByName(($env:computerName)).Hostname)
+		$url = $serverbaseurl + "reqcert?hostname=$hostname"
 		try {
 			$r = http $url "get" 60
 		} catch {
@@ -584,7 +585,8 @@ if ($haveCert -and -not $certWorks) {
 }
 elseif (-not $haveCert) {
 	Write-Host "I don't have a certificate, requesting one now..."
-	$url = $serverbaseurl + "reqcert?nopass=1"
+	$hostname = [System.Web.HttpUtility]::UrlEncode([System.Net.Dns]::GetHostByName(($env:computerName)).Hostname)
+	$url = $serverbaseurl + "reqcert?hostname=$hostname"
 	$r = $null
 	$ok = $false
 	try {

--- a/client/windows/test_windows_client.sh
+++ b/client/windows/test_windows_client.sh
@@ -38,7 +38,7 @@ echo "IP address: \"$WINIP\""
 echo "Creating a Fedora VM..."
 FED="Trilby"
 openstack server delete --wait $FED 2>/dev/null || true # just to be sure
-openstack server create --flavor m1.small --image "GOLD Fedora 31" --nic net-id=dualStack --key-name $KEYPAIRNAME --wait $FED
+openstack server create --flavor m1.small --image "GOLD Fedora 32" --nic net-id=dualStack --key-name $KEYPAIRNAME --wait $FED
 FEDIP=$(openstack server list | grep $FED | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
 echo "IP address: \"$FEDIP\""
 

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.7
+Version:  2.7.8
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/rpm/run_tests_on_vms.sh
+++ b/rpm/run_tests_on_vms.sh
@@ -38,7 +38,7 @@ rm $TMPFILE
 # Clean up the list, only keep the images we want to test on
 IMAGES=()
 for IMAGE in "${LIST[@]}"; do
-	if [[ $IMAGE != *"Fedora 31"* ]] && [[ $IMAGE != *"CentOS 7"* ]]; then
+	if [[ $IMAGE != *"Fedora 32"* ]] && [[ $IMAGE != *"CentOS 7"* ]]; then
 		continue
 	fi
 	IMAGE=$(echo $IMAGE | xargs) # trim leading/trailing whitespace


### PR DESCRIPTION
- The Windows client didn't pass its hostname as a parameter when requesting a new certificate. This became required a while back, and it seems I forgot to add it to the Windows client. Windows hosts on subnets where DNS couldn't be used to determine the hostname were unable to get a new certificate.
- Updated the test scripts to use the Fedora 32 image for VMs