### PR TITLE
Convert hostnames to lowercase, and parse macOS 11

### DIFF
--- a/client/windows/nivlheim_client.ps1
+++ b/client/windows/nivlheim_client.ps1
@@ -33,7 +33,7 @@ param(
 	[bool]$nosleep = $false
 )
 
-Set-Variable version -option Constant -value "2.7.8"
+Set-Variable version -option Constant -value "2.7.9"
 Set-Variable useragent -option Constant -value "NivlheimPowershellClient/$version"
 Set-PSDebug -strict
 Set-StrictMode -version "Latest"	# http://technet.microsoft.com/en-us/library/hh849692.aspx

--- a/rpm/nivlheim.spec
+++ b/rpm/nivlheim.spec
@@ -2,7 +2,7 @@
 
 # Semantic Versioning http://semver.org/
 Name:     nivlheim
-Version:  2.7.8
+Version:  2.7.9
 Release:  %{date}%{?dist}
 
 Summary:  File collector

--- a/server/cgi/post
+++ b/server/cgi/post
@@ -92,6 +92,7 @@ eval {
 		return;
 	}
 	$logger->debug("client says its hostname is $os_hostname");
+	$os_hostname = lc $os_hostname;
 	$shorthost = $os_hostname;
 	if ($shorthost =~ /^(\S+?)\./) { $shorthost = $1; }
 	my $clientversion =	$query->param('version');

--- a/server/service/parseFiles.go
+++ b/server/service/parseFiles.go
@@ -221,10 +221,10 @@ func parseFile(database *sql.DB, fileID int64) {
 	}
 
 	if filename.String == "/usr/bin/sw_vers" {
-		re := regexp.MustCompile(`ProductName:\s+Mac OS X\nProductVersion:\s+(\d+\.\d+)`)
+		re := regexp.MustCompile(`ProductName:\s+(Mac OS X|macOS)\nProductVersion:\s+(\d+\.\d+)`)
 		if m := re.FindStringSubmatch(content.String); m != nil {
 			_, err = tx.Exec("UPDATE hostinfo SET os=$1, os_edition=null, os_family='macOS' "+
-				"WHERE certfp=$2", "macOS "+m[1], certfp.String)
+				"WHERE certfp=$2", "macOS "+m[2], certfp.String)
 		}
 		return
 	}

--- a/server/service/parseFiles_test.go
+++ b/server/service/parseFiles_test.go
@@ -311,6 +311,13 @@ ProductVersion: 10.13.3
 BuildVersion:   17D102`,
 		},
 		{
+			osLabel: "macOS 11.2",
+			filename: "/usr/bin/sw_vers",
+			content: `ProductName:	macOS
+ProductVersion:	11.2.1
+BuildVersion:	20D74`,
+		},
+		{
 			osLabel:  "FreeBSD 11",
 			filename: "/bin/freebsd-version -ku",
 			content:  "11.1-RELEASE-p6",


### PR DESCRIPTION
- Some Windows machines report their hostname in uppercase. This PR adds code that converts all hostnames to lower case internally.
- The code doesn't properly display the OS version for machines with macOS 11, this patch fixes that.