### PR TITLE
Client certificates get Subject Alternative Name

### DIFF
--- a/ci/docker/client_build.sh
+++ b/ci/docker/client_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd `dirname $0`/../..  # cd to the root of the git repo
 cp client/client.yaml tmp_client.yaml
-echo "server=localhost" >> tmp_client.yaml
+echo "  server: localhost" >> tmp_client.yaml
 docker build -f ci/docker/client_Dockerfile --tag nivlheimclient:latest .
 rm tmp_client.yaml

--- a/server/cgi/renewcert
+++ b/server/cgi/renewcert
@@ -106,9 +106,11 @@ $logger->debug("Hostname is: $hostname");
 eval {
 	# Generate client key
 	my $cmd = "openssl genrsa -out $keyfile 4096 2>/dev/null";
-
 	(system($cmd) == 0 and -f $keyfile) or die "Key generation failed: $?";
 	$logger->debug("Key OK.");
+
+	# The openssl config gets the name from the environment
+	$ENV{'COMMONNAME'} = $hostname;
 
 	# Generate client certificate request
 	$cmd = "openssl req -new -key $keyfile -out $csrfile -config $opensslconf";
@@ -125,7 +127,7 @@ eval {
 	# openssl will store the pem-file in the certs directory (see openssl_ca.conf)
 	$cmd = "openssl ca -batch -in $csrfile -cert $confdir/CA/nivlheimca.crt"
 		." -keyfile $confdir/CA/nivlheimca.key"
-		." -subj '/C=NO/ST=Norway/O=UiO/OU=USIT/CN=$hostname'"
+		." -extensions req_ext"
 		." -out $crtfile -config $opensslconf 2>/var/log/nivlheim/sign.log";
 	if (!(system($cmd) == 0 and -f $crtfile)) {
 		$logger->debug($cmd);

--- a/server/cgi/reqcert
+++ b/server/cgi/reqcert
@@ -88,7 +88,7 @@ if ($cgi->param('cfe_key_md5') && $cgi->param('sign_b64') &&
 	open(my $F, $convertedkeyfile);
 	$logger->debug("First line: ".<$F>);
 	close($F);
-	
+
 	open($F,">$sigfile");
 	binmode $F;
 	my $base64 = $cgi->param('sign_b64');
@@ -187,9 +187,11 @@ my $p12file = "/tmp/user$id.p12";
 eval {
 	# Generate client key
 	my $cmd = "openssl genrsa -out $keyfile 4096 2>/dev/null";
-
 	(system($cmd) == 0 and -f $keyfile) or die "Key generation failed: $?";
 	print "Key OK.\n";
+
+	# The openssl config gets the name from the environment
+	$ENV{'COMMONNAME'} = $hostname;
 
 	# Generate client certificate request
 	$cmd = "openssl req -new -key $keyfile -out $csrfile -config $opensslconf";
@@ -206,7 +208,7 @@ eval {
 	# openssl will store the pem-file in the certs directory (see openssl_ca.conf)
 	$cmd = "openssl ca -batch -in $csrfile -cert $confdir/CA/nivlheimca.crt"
 		." -keyfile $confdir/CA/nivlheimca.key"
-		." -subj '/C=NO/ST=Norway/O=UiO/OU=USIT/CN=$hostname'"
+		." -extensions req_ext"
 		." -out $crtfile -config $opensslconf 2>/var/log/nivlheim/sign.log";
 	if (!(system($cmd) == 0 and -f $crtfile)) {
 		$logger->debug($cmd);

--- a/server/client_CA_cert.sh
+++ b/server/client_CA_cert.sh
@@ -56,6 +56,7 @@ if [[ $CREATE -eq 1 ]]; then
 
 		# Generate a new certificate
 		rm -f old_*
+		export COMMONNAME=Nivlheim2022
 		openssl genrsa -out new_nivlheimca.key 4096 >/dev/null 2>&1
 		openssl req -new -key new_nivlheimca.key -out new_nivlheimca.csr -subj "/C=NO/ST=Oslo/L=Oslo/O=UiO/OU=USIT/CN=Nivlheim$RANDOM"
 		openssl x509 -req -days 365 -in new_nivlheimca.csr -out new_nivlheimca.crt -signkey new_nivlheimca.key >/dev/null 2>&1

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -43,6 +43,7 @@ if [ ! -f default_cert.pem ] || [ ! -f default_key.pem ]; then
 	openssl genpkey -outform PEM -out default_key.pem -algorithm RSA \
 	  -pkeyopt rsa_keygen_bits:4096
 	# certificate request
+	export COMMONNAME=localhost
 	openssl req -new -key default_key.pem -out csr -days 365 \
 	  -subj "/C=NO/ST=Oslo/L=Oslo/O=UiO/OU=USIT/CN=localhost"
 	# sign the request

--- a/server/openssl_ca.conf
+++ b/server/openssl_ca.conf
@@ -32,6 +32,7 @@ default_keyfile    = privkey.pem
 distinguished_name = req_distinguished_name
 attributes         = req_attributes
 x509_extensions    = v3_ca # The extensions to add to the self signed cert
+req_extensions     = req_ext
 prompt             = no
 string_mask        = default
 
@@ -41,9 +42,12 @@ stateOrProvinceName             = Norway   # State or Province Name (full name)
 localityName                    = Oslo   # Locality
 0.organizationName              = UiO
 organizationalUnitName          = USIT   # Organizational Unit
-commonName                      = Nivlheim2022
+commonName                      = ${ENV::COMMONNAME}
 
 [ req_attributes ]
+
+[ req_ext ]
+subjectAltName = DNS:${ENV::COMMONNAME}
 
 [ v3_req ]
 basicConstraints = CA:FALSE


### PR DESCRIPTION
Add the Subject Alternative Name field to client certificates, in addition to CommonName. Resolves #170.