### PR TITLE
Add CA certificate bundle to server Docker image.

### DIFF
--- a/manifest.scm
+++ b/manifest.scm
@@ -5,6 +5,7 @@
              (guix packages)
              (guix gexp)
              ((guix git-download) #:select (git-predicate))
+             (gnu packages certs)
              (uio packages nivlheim))
 
 (define %checkout (dirname (current-filename)))
@@ -36,7 +37,8 @@
       (string=? ref "HEAD")))
 
 (packages->manifest
- (list (package
+ (list nss-certs                        ;CA certificates
+       (package
          ;; Return a variant of Nivlheim that uses the local checkout as
          ;; source, and with a custom version based on the contents of
          ;; the VERSION file and the current branch.

--- a/manifest.scm
+++ b/manifest.scm
@@ -36,16 +36,22 @@
       ;; when not on a branch.
       (string=? ref "HEAD")))
 
+(define %nivlheim
+  (package
+    (inherit nivlheim)
+    ;; Custom variant of Nivlheim that uses the local checkout as source,
+    ;; and with "version" set to the contents of the VERSION file and
+    ;; current branch.
+    (version (if (or (string=? ref "master") (ref-is-tag? ref))
+                 version
+                 (string-append version "-" ref)))
+    (source (local-file %checkout
+                        #:recursive? #t
+                        #:select? (git-predicate %checkout)))
+    ;; Propagate nss-certs to ensure /etc/ssl/certs is available.
+    (propagated-inputs
+     (append (list nss-certs)
+             (package-propagated-inputs nivlheim)))))
+
 (packages->manifest
- (list nss-certs                        ;CA certificates
-       (package
-         ;; Return a variant of Nivlheim that uses the local checkout as
-         ;; source, and with a custom version based on the contents of
-         ;; the VERSION file and the current branch.
-         (inherit nivlheim)
-         (version (if (or (string=? ref "master") (ref-is-tag? ref))
-                      version
-                      (string-append version "-" ref)))
-         (source (local-file %checkout
-                             #:recursive? #t
-                             #:select? (git-predicate %checkout))))))
+ (list %nivlheim))


### PR DESCRIPTION
This change along with https://github.com/unioslo/guix-uio/commit/ca3f77c32c896026a4ba77d9c8d4f959337c0d71 makes the server image able to validate certificates signed by the global trust anchors.