### PR TITLE
Sende certs kompatibelt for gamle klienter + noen småting

### DIFF
--- a/server/cgi/renewcert
+++ b/server/cgi/renewcert
@@ -189,7 +189,13 @@ eval {
 	print; print while (<F>);
 	close(F);
 	open(F, $keyfile) or die "Can't read key file";
-	print while (<F>);
+	#print while (<F>);
+	# We need the header to be PKCS#1 format for now
+	# https://stackoverflow.com/questions/20065304/differences-between-begin-rsa-private-key-and-begin-private-key
+	while (<F>) {
+		s/PRIVATE KEY/RSA PRIVATE KEY/;
+		print;
+	}
 	close(F);
 
 	# Display the P12-file, base64-encoded

--- a/server/cgi/reqcert
+++ b/server/cgi/reqcert
@@ -254,7 +254,13 @@ eval {
 	print; print while (<F>);
 	close(F);
 	open(F, $keyfile) or die "Can't read key file";
-	print while (<F>);
+	#print while (<F>);
+	# We need the header to be PKCS#1 format for now
+	# https://stackoverflow.com/questions/20065304/differences-between-begin-rsa-private-key-and-begin-private-key
+	while (<F>) {
+		s/PRIVATE KEY/RSA PRIVATE KEY/;
+		print;
+	}
 	close(F);
 
 	# Display the P12-file, base64-encoded

--- a/server/service/handleDNSchanges_test.go
+++ b/server/service/handleDNSchanges_test.go
@@ -81,7 +81,7 @@ func TestHandleDNSchanges(t *testing.T) {
 		// this host will be renamed based on DNS PTR record for the ip address
 		testname{
 			certfp:     "a",
-			ipAddress:  "129.240.202.63",
+			ipAddress:  "129.240.130.240",
 			osHostname: "bottleneck.bestchoice.com",
 			expected:   "callisto.uio.no",
 		},

--- a/server/service/parseFiles.go
+++ b/server/service/parseFiles.go
@@ -148,7 +148,7 @@ func parseFile(database *sql.DB, fileID int64) {
 	if filename.String == "/etc/redhat-release" {
 		var os, osEdition string
 		rhel := regexp.MustCompile("^Red Hat Enterprise Linux (\\w+)" +
-			".*(Tikanga|Santiago|Maipo|Ootpa)")
+			".*(Tikanga|Santiago|Maipo|Ootpa|Plow)")
 		m := rhel.FindStringSubmatch(content.String)
 		if m != nil {
 			osEdition = m[1]
@@ -162,6 +162,9 @@ func parseFile(database *sql.DB, fileID int64) {
 			case "Ootpa":
 				os = "RHEL 8"
 				osEdition = "" // RHEL 8 doesn't come in workstation+server editions like the previous versions
+			case "Plow":
+				os = "RHEL 9"
+				osEdition = ""
 			}
 		} else {
 			fedora := regexp.MustCompile("^Fedora release (\\d+)")

--- a/server/service/parseFiles_test.go
+++ b/server/service/parseFiles_test.go
@@ -286,6 +286,11 @@ func TestOSdetection(t *testing.T) {
 			content:  "Red Hat Enterprise Linux release 8.0 (Ootpa)",
 		},
 		{
+			osLabel:  "RHEL 9",
+			filename: "/etc/redhat-release",
+			content:  "Red Hat Enterprise Linux release 9.0 (Plow)",
+		},
+		{
 			osLabel:  "AlmaLinux 8",
 			filename: "/etc/redhat-release",
 			content:  "AlmaLinux release 8.6 (Sky Tiger)",


### PR DESCRIPTION
- Fix a bug in one of the unit tests for DNS changes
- Detect RHEL 9
- Ensure the certs have the PKCS#1 header (tmp hack)